### PR TITLE
Fix memory leak and add minimal tests for PythonQt::init

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,15 @@ jobs:
         PYTHONDEVMODE=1 PYTHONASYNCIODEBUG=1 PYTHONWARNINGS=error PYTHONMALLOC=malloc_debug \
         UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
           make check TESTARGS="-platform offscreen"
-      
+
+    - name: Run minimal tests with sanitizers
+      run: |
+        cd lib
+        PYTHONDEVMODE=1 PYTHONASYNCIODEBUG=1 PYTHONWARNINGS=error PYTHONMALLOC=malloc_debug \
+        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
+        RUN_ONLY_MINIMAL_TESTS="true" ./PythonQtTest
+        RUN_ONLY_MINIMAL_TESTS="true" ./PythonQtTest -platform minimal
+        
     - name: Generate Wrappers
       run: |
         # workaround to allow to find the Qt include dirs for installed standard qt packages

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1898,7 +1898,11 @@ void PythonQt::initPythonQtModule(bool redirectStdOut, const QByteArray& pythonQ
   Py_XDECREF(old_module_names);
 
 #ifdef PY3K
-  PyDict_SetItem(PyObject_GetAttrString(sys.object(), "modules"), PyUnicode_FromString(name.constData()), _p->_pythonQtModule.object());
+  PyObject* modulesAttr = PyObject_GetAttrString(sys.object(), "modules");
+  PyObject* pyUnicodeObject = PyUnicode_FromString(name.constData());
+  PyDict_SetItem(modulesAttr, pyUnicodeObject, _p->_pythonQtModule.object());
+  Py_XDECREF(modulesAttr);
+  Py_XDECREF(pyUnicodeObject);
 #endif
 }
 

--- a/tests/PythonQtTestMain.cpp
+++ b/tests/PythonQtTestMain.cpp
@@ -47,6 +47,18 @@
 int main( int argc, char **argv )
 {
   QApplication qapp(argc, argv);
+  QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+
+  if (env.contains("RUN_ONLY_MINIMAL_TESTS")) {
+    PythonQtMinimalTests test;
+    auto result = QTest::qExec(&test, argc, argv);
+    if (result) {
+      std::cerr << "Minimal Tests failed";
+    } else {
+      std::cout << "Minimal tests passed successfully." << std::endl;
+    }
+    return result != 0 ? EXIT_FAILURE : EXIT_SUCCESS;
+  }
 
   PythonQt::init(PythonQt::IgnoreSiteModule | PythonQt::RedirectStdOut);
 
@@ -59,6 +71,9 @@ int main( int argc, char **argv )
   failCount += QTest::qExec(&slotCalling, argc, argv);
 
   PythonQt::cleanup();
+
+  PythonQtMinimalTests test;
+  failCount += QTest::qExec(&test, argc, argv);
 
   if (failCount) {
     std::cerr << "Tests failed: " << failCount << std::endl;

--- a/tests/PythonQtTests.cpp
+++ b/tests/PythonQtTests.cpp
@@ -41,6 +41,41 @@
 
 #include "PythonQtTests.h"
 
+void PythonQtMinimalTests::baseInitTest()
+{
+  PythonQt::init();
+  PythonQt::cleanup();
+}
+
+void PythonQtMinimalTests::initWithFlagsTest()
+{
+  PythonQt::init(PythonQt::IgnoreSiteModule | PythonQt::RedirectStdOut);
+  PythonQt::cleanup();
+}
+
+void PythonQtMinimalTests::simpleInitAlreadyInitializedTest()
+{
+  Py_InitializeEx(true);
+  PythonQt::init(PythonQt::PythonAlreadyInitialized);
+  PythonQt::cleanup();
+}
+
+void PythonQtMinimalTests::severalInitializeTest() {
+  PythonQt::init();
+  PythonQt::cleanup();
+
+  PythonQt::init();
+  PythonQt::cleanup();
+}
+
+void PythonQtMinimalTests::initWithPreconfigTest() {
+  PyConfig config;
+  PyConfig_InitPythonConfig(&config);
+  Py_InitializeFromConfig(&config);
+  PythonQt::init(PythonQt::RedirectStdOut | PythonQt::PythonAlreadyInitialized);
+  PythonQt::cleanup();
+}
+
 void PythonQtTestSlotCalling::initTestCase()
 {
   _helper = new PythonQtTestSlotCallingHelper(this);

--- a/tests/PythonQtTests.h
+++ b/tests/PythonQtTests.h
@@ -58,6 +58,18 @@ class PythonQtTestSlotCallingHelper;
 class PythonQtTestApiHelper;
 class QWidget;
 
+class PythonQtMinimalTests : public QObject
+{
+  Q_OBJECT
+
+private Q_SLOTS:
+  void baseInitTest();
+  void initWithFlagsTest();
+  void severalInitializeTest();
+  void initWithPreconfigTest();
+  void simpleInitAlreadyInitializedTest();
+};
+
 //! test the PythonQt api
 class PythonQtTestApi : public QObject
 {


### PR DESCRIPTION
1. Return value for PyUnicode_FromString is a new reference, but PyDict_SetItem INCREF for it, which leads to a leak, especially with multiple Py_Initialize().
2. Add minimal init tests for detecting similar memory leak.
3. Add tests for CI with ASAN_OPTIONS="detect_leaks=1".