### PR TITLE
Fix macOS and centos CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,14 @@ on:
     branches: 
       - master
   pull_request:
-      
+   
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+   
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    
 defaults:
   run:
     shell: bash
@@ -93,6 +100,13 @@ jobs:
     runs-on: ubuntu-latest
     container: '${{ matrix.container_os }}:${{ matrix.container_os_version }}'
     steps:
+    - name: Change centos archive repository
+      run: |
+        sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+        sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+        sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+      if: matrix.container_os == 'centos'
+      
     - name: Install Qt
       run: |
         yum update -y
@@ -147,8 +161,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       macos-version:  ['11']
-       python-version: ['3.6']
+       macos-version:  ['12']
+       python-version: ['3.9']
        qt-version: ['5.9.*']
        configuration: ['release','debug']
        include:


### PR DESCRIPTION
1. node20 requires at least glibc2.27, which is not available in centos, upgrading the glibc version contradicts the meaning of using older centos.
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
2. macOS-11 runner is no longer supported on GHA, so macOS-12 with python3.9 is used
https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal
3. mirrorlist.centos.org not available, switch to vault
https://serverfault.com/questions/904304/could-not-resolve-host-mirrorlist-centos-org-centos-7
4. Add cancel running workflow from the same PR
